### PR TITLE
Add GPT-2 fine-tuning demo with FastAPI + Sentry

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+SENTRY_DSN=
+ENVIRONMENT=development
+HF_MODEL_NAME=gpt2

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # kp-llm
-First LLM 20250622
+
+This minimal project fine-tunes GPT-2 on the Wikitext-2 dataset and exposes a FastAPI service to generate text. Sentry is used for error logging and performance tracing.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Create a `.env` file based on the provided template:
+   ```env
+   SENTRY_DSN=<your dsn>
+   ENVIRONMENT=development
+   HF_MODEL_NAME=gpt2
+   ```
+3. Train the model (optional, will use pre-trained GPT-2 if not run):
+   ```bash
+   python model.py
+   ```
+4. Start the API server:
+   ```bash
+   uvicorn main:app --reload
+   ```

--- a/llm_utils.py
+++ b/llm_utils.py
@@ -1,0 +1,43 @@
+import os
+import time
+import hashlib
+import torch
+import sentry_sdk
+from transformers import GPT2TokenizerFast, GPT2LMHeadModel
+
+
+def load_model():
+    model_name = os.getenv("HF_MODEL_NAME", "gpt2")
+    if os.path.exists("./trained_model"):
+        model = GPT2LMHeadModel.from_pretrained("./trained_model")
+    else:
+        model = GPT2LMHeadModel.from_pretrained(model_name)
+    tokenizer = GPT2TokenizerFast.from_pretrained(model_name)
+    model.eval()
+    return model, tokenizer
+
+
+def generate_with_token_latency(model, tokenizer, prompt: str, max_new_tokens: int = 20):
+    input_ids = tokenizer.encode(prompt, return_tensors="pt")
+    past_key_values = None
+    output_ids = []
+    token_latencies = []
+    with torch.no_grad():
+        for idx in range(max_new_tokens):
+            with sentry_sdk.start_span(op="llm.token", description=f"token_{idx}") as span:
+                start = time.perf_counter()
+                outputs = model(input_ids=input_ids, past_key_values=past_key_values, use_cache=True)
+                past_key_values = outputs.past_key_values
+                next_token_logits = outputs.logits[:, -1, :]
+                next_token_id = torch.argmax(next_token_logits, dim=-1, keepdim=True)
+                latency = (time.perf_counter() - start) * 1000
+                span.set_tag("latency_ms", latency)
+            token_latencies.append(latency)
+            output_ids.append(next_token_id.item())
+            input_ids = next_token_id
+    generated_text = tokenizer.decode(output_ids, skip_special_tokens=True)
+    return generated_text, token_latencies
+
+
+def hash_prompt(prompt: str) -> str:
+    return hashlib.md5(prompt.encode()).hexdigest()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,51 @@
+import os
+import time
+from fastapi import FastAPI
+from pydantic import BaseModel
+import sentry_sdk
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+
+from sentry_setup import init_sentry
+from llm_utils import load_model, generate_with_token_latency, hash_prompt
+
+init_sentry()
+
+app = FastAPI()
+app.add_middleware(SentryAsgiMiddleware)
+
+model, tokenizer = load_model()
+
+class GenerationRequest(BaseModel):
+    user_id: str
+    prompt: str
+    max_tokens: int = 20
+
+
+@app.post("/generate")
+async def generate(req: GenerationRequest):
+    prompt_hash = hash_prompt(req.prompt)
+    with sentry_sdk.start_span(op="llm.prompt_response", description="prompt+response"):
+        start_time = time.perf_counter()
+        text, token_latencies = generate_with_token_latency(model, tokenizer, req.prompt, req.max_tokens)
+        generation_latency_ms = (time.perf_counter() - start_time) * 1000
+    sentry_sdk.add_breadcrumb(
+        category="llm",
+        message="prompt processed",
+        level="info",
+        data={
+            "user_id": req.user_id,
+            "prompt_hash": prompt_hash,
+            "token_count": len(token_latencies),
+            "generation_latency_ms": generation_latency_ms,
+        },
+    )
+    return {
+        "text": text,
+        "token_count": len(token_latencies),
+        "latencies_ms": token_latencies,
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("main:app", host="0.0.0.0", port=8000)

--- a/model.py
+++ b/model.py
@@ -1,0 +1,40 @@
+import os
+from datasets import load_dataset
+from transformers import (GPT2TokenizerFast, GPT2LMHeadModel,
+                          DataCollatorForLanguageModeling, Trainer,
+                          TrainingArguments)
+
+
+def train():
+    model_name = os.getenv("HF_MODEL_NAME", "gpt2")
+    dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="train[:1%]")
+    tokenizer = GPT2TokenizerFast.from_pretrained(model_name)
+
+    def tokenize(batch):
+        return tokenizer(batch["text"], truncation=True, max_length=128)
+
+    tokenized_ds = dataset.map(tokenize, batched=True, remove_columns=["text"])
+    data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+    model = GPT2LMHeadModel.from_pretrained(model_name)
+
+    args = TrainingArguments(
+        output_dir="./results",
+        overwrite_output_dir=True,
+        num_train_epochs=1,
+        per_device_train_batch_size=2,
+        save_steps=10,
+        logging_steps=10,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=args,
+        train_dataset=tokenized_ds,
+        data_collator=data_collator,
+    )
+    trainer.train()
+    trainer.save_model("./trained_model")
+
+
+if __name__ == "__main__":
+    train()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+transformers
+datasets
+torch
+fastapi
+uvicorn
+sentry-sdk
+python-dotenv

--- a/sentry_setup.py
+++ b/sentry_setup.py
@@ -1,0 +1,11 @@
+import os
+from dotenv import load_dotenv
+import sentry_sdk
+
+def init_sentry():
+    load_dotenv()
+    sentry_sdk.init(
+        dsn=os.getenv("SENTRY_DSN"),
+        environment=os.getenv("ENVIRONMENT"),
+        traces_sample_rate=1.0,
+    )


### PR DESCRIPTION
## Summary
- train GPT-2 on the Wikitext-2 dataset
- serve the model with FastAPI and instrument it with Sentry
- include helper utilities and Sentry setup
- document setup in README
- provide requirements and `.env` template

## Testing
- `python -m py_compile main.py model.py llm_utils.py sentry_setup.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6857d66643548326b5aa92676872dc25